### PR TITLE
fix: Dashboard: Project name filter persists on navigation

### DIFF
--- a/metrics/web/lib/dashboard/presentation/pages/dashboard_page.dart
+++ b/metrics/web/lib/dashboard/presentation/pages/dashboard_page.dart
@@ -31,6 +31,7 @@ class _DashboardPageState extends State<DashboardPage> {
     _projectMetricsNotifier =
         Provider.of<ProjectMetricsNotifier>(context, listen: false);
 
+    _projectMetricsNotifier.resetProjectNameFilter();
     _projectMetricsNotifier.addListener(_projectsErrorListener);
   }
 

--- a/metrics/web/lib/dashboard/presentation/pages/dashboard_page.dart
+++ b/metrics/web/lib/dashboard/presentation/pages/dashboard_page.dart
@@ -23,7 +23,9 @@ class _DashboardPageState extends State<DashboardPage> {
   @override
   void initState() {
     super.initState();
+
     _subscribeToProjectsErrors();
+    _projectMetricsNotifier.resetProjectNameFilter();
   }
 
   /// Subscribes to projects errors.
@@ -31,7 +33,6 @@ class _DashboardPageState extends State<DashboardPage> {
     _projectMetricsNotifier =
         Provider.of<ProjectMetricsNotifier>(context, listen: false);
 
-    _projectMetricsNotifier.resetProjectNameFilter();
     _projectMetricsNotifier.addListener(_projectsErrorListener);
   }
 

--- a/metrics/web/lib/dashboard/presentation/state/project_metrics_notifier.dart
+++ b/metrics/web/lib/dashboard/presentation/state/project_metrics_notifier.dart
@@ -162,6 +162,11 @@ class ProjectMetricsNotifier extends ChangeNotifier {
     _projectNameFilterSubject.add(value);
   }
 
+  /// Resets the project name filter.
+  void resetProjectNameFilter() {
+    _projectNameFilter = null;
+  }
+
   /// Sets the [selectedProjectGroup] to project group with the given [id].
   void selectProjectGroup(String id) {
     final projectGroup = _projectGroupDropdownItems.firstWhere(

--- a/metrics/web/test/dashboard/presentation/state/project_metrics_notifier_test.dart
+++ b/metrics/web/test/dashboard/presentation/state/project_metrics_notifier_test.dart
@@ -334,6 +334,25 @@ void main() {
     );
 
     test(
+      ".resetProjectNameFilter() resets the project name filter",
+      () async {
+        const projectNameFilter = 'filter name';
+
+        final listener = expectAsyncUntil0(
+          () {
+            if (projectMetricsNotifier.projectNameFilter != null) {
+              projectMetricsNotifier.resetProjectNameFilter();
+            }
+          },
+          () => projectMetricsNotifier.projectNameFilter == null,
+        );
+
+        projectMetricsNotifier.addListener(listener);
+        projectMetricsNotifier.filterByProjectName(projectNameFilter);
+      },
+    );
+
+    test(
       ".filterByProjectName() doesn't apply filters to the list of the project metrics if the given value is null",
       () async {
         final expectedProjectMetrics =

--- a/metrics/web/test/test_utils/project_metrics_notifier_stub.dart
+++ b/metrics/web/test/test_utils/project_metrics_notifier_stub.dart
@@ -61,6 +61,9 @@ class ProjectMetricsNotifierStub extends ChangeNotifier
   void filterByProjectName(String value) {}
 
   @override
+  void resetProjectNameFilter() {}
+
+  @override
   Future<void> setProjects(
       List<ProjectModel> newProjectModels, String projectErrorMessage) async {
     return;


### PR DESCRIPTION
Fixes #505 

## Checklist

- [x] Documented
- [x] Unit tested

### Behavior before:
![2020-09-04 13 59 54](https://user-images.githubusercontent.com/69351065/92232289-fb8cf900-eeb6-11ea-9cd9-c99c6fbd6534.gif)

### Behavior now:
![2020-09-04 14 00 57](https://user-images.githubusercontent.com/69351065/92232433-34c56900-eeb7-11ea-9333-ea4704a439c6.gif)

