### PR TITLE
fix: Fix password visibility icon color in Light Theme

### DIFF
--- a/metrics/web/lib/auth/presentation/widgets/auth_form.dart
+++ b/metrics/web/lib/auth/presentation/widgets/auth_form.dart
@@ -7,6 +7,7 @@ import 'package:metrics/auth/presentation/widgets/sign_in_option_button.dart';
 import 'package:metrics/auth/presentation/widgets/strategy/google_sign_in_option_strategy.dart';
 import 'package:metrics/base/presentation/widgets/tappable_area.dart';
 import 'package:metrics/common/presentation/button/widgets/metrics_positive_button.dart';
+import 'package:metrics/common/presentation/metrics_theme/widgets/metrics_theme.dart';
 import 'package:metrics/common/presentation/widgets/metrics_text_form_field.dart';
 import 'package:provider/provider.dart';
 
@@ -31,6 +32,8 @@ class _AuthFormState extends State<AuthForm> {
 
   @override
   Widget build(BuildContext context) {
+    final iconColor =
+        MetricsTheme.of(context).loginTheme.passwordVisibilityIconColor;
     final passwordIcon =
         _isPasswordObscure ? 'icons/eye_on.svg' : 'icons/eye_off.svg';
 
@@ -60,7 +63,10 @@ class _AuthFormState extends State<AuthForm> {
                   suffixIcon: TappableArea(
                     onTap: _changePasswordObscure,
                     builder: (context, isHovered, child) => child,
-                    child: Image.network(passwordIcon),
+                    child: Image.network(
+                      passwordIcon,
+                      color: iconColor,
+                    ),
                   ),
                 ),
               ),

--- a/metrics/web/lib/common/presentation/metrics_theme/model/dark_metrics_theme_data.dart
+++ b/metrics/web/lib/common/presentation/metrics_theme/model/dark_metrics_theme_data.dart
@@ -285,6 +285,7 @@ class DarkMetricsThemeData extends MetricsThemeData {
                 fontWeight: FontWeight.w500,
               ),
             ),
+            passwordVisibilityIconColor: Colors.white,
           ),
           projectMetricsTableTheme: const ProjectMetricsTableThemeData(
             metricsTableHeaderTheme: MetricsTableHeaderThemeData(

--- a/metrics/web/lib/common/presentation/metrics_theme/model/light_metrics_theme_data.dart
+++ b/metrics/web/lib/common/presentation/metrics_theme/model/light_metrics_theme_data.dart
@@ -73,7 +73,7 @@ class LightMetricsThemeData extends MetricsThemeData {
   static const Color _negativeStatusColor = Color(0xFFFFF5F3);
   static const Color _neutralStatusColor = Color(0xFFFAF6E6);
   static const Color _inactiveStatusColor = Color(0xFF43494D);
-  static const Color _dropdownMenuIconColor = Color(0xFF2d2d33);
+  static const Color _iconColor = Color(0xFF2d2d33);
 
   static const inputFocusedBorder = OutlineInputBorder(
     borderSide: BorderSide(color: _inputFocusedBorderColor),
@@ -267,7 +267,7 @@ class LightMetricsThemeData extends MetricsThemeData {
             closedButtonBorderColor: inputColor,
             textStyle: _defaultDropdownTextStyle,
             shadowColor: _shadowColor,
-            iconColor: _dropdownMenuIconColor,
+            iconColor: _iconColor,
           ),
           dropdownItemTheme: const DropdownItemThemeData(
             backgroundColor: Colors.white,
@@ -299,6 +299,7 @@ class LightMetricsThemeData extends MetricsThemeData {
                 lineHeightInPixels: 20.0,
               ),
             ),
+            passwordVisibilityIconColor: _iconColor,
           ),
           projectMetricsTableTheme: const ProjectMetricsTableThemeData(
             metricsTableHeaderTheme: MetricsTableHeaderThemeData(

--- a/metrics/web/lib/common/presentation/metrics_theme/model/login_theme_data.dart
+++ b/metrics/web/lib/common/presentation/metrics_theme/model/login_theme_data.dart
@@ -9,14 +9,15 @@ class LoginThemeData {
   /// A [MetricsButtonStyle] for buttons with login options.
   final MetricsButtonStyle loginOptionButtonStyle;
 
-  /// A [Color] ot the password visibility icon color.
+  /// A [Color] of the password visibility icon.
   final Color passwordVisibilityIconColor;
 
   /// Creates a new instance of the [LoginThemeData].
   ///
   /// The [loginOptionButtonStyle] defaults to an empty
   /// [MetricsButtonStyle] instance.
-  /// The [passwordVisibilityIconColor] defaults to [Colors.grey];
+  /// If the [passwordVisibilityIconColor] is `null`, the
+  /// [Colors.grey] is used.
   const LoginThemeData({
     this.loginOptionButtonStyle = const MetricsButtonStyle(),
     this.titleTextStyle,

--- a/metrics/web/lib/common/presentation/metrics_theme/model/login_theme_data.dart
+++ b/metrics/web/lib/common/presentation/metrics_theme/model/login_theme_data.dart
@@ -9,12 +9,17 @@ class LoginThemeData {
   /// A [MetricsButtonStyle] for buttons with login options.
   final MetricsButtonStyle loginOptionButtonStyle;
 
+  /// A [Color] ot the password visibility icon color.
+  final Color passwordVisibilityIconColor;
+
   /// Creates a new instance of the [LoginThemeData].
   ///
   /// The [loginOptionButtonStyle] defaults to an empty
   /// [MetricsButtonStyle] instance.
+  /// The [passwordVisibilityIconColor] defaults to [Colors.grey];
   const LoginThemeData({
     this.loginOptionButtonStyle = const MetricsButtonStyle(),
     this.titleTextStyle,
-  });
+    Color passwordVisibilityIconColor,
+  }) : passwordVisibilityIconColor = passwordVisibilityIconColor ?? Colors.grey;
 }

--- a/metrics/web/test/auth/presentation/widgets/auth_form_test.dart
+++ b/metrics/web/test/auth/presentation/widgets/auth_form_test.dart
@@ -250,7 +250,7 @@ void main() {
     );
 
     testWidgets(
-      "applies the password visibility icon color from the metrics theme",
+      "applies the color from the metrics theme to the password visibility icon",
       (WidgetTester tester) async {
         await mockNetworkImagesFor(
           () => tester.pumpWidget(

--- a/metrics/web/test/auth/presentation/widgets/auth_form_test.dart
+++ b/metrics/web/test/auth/presentation/widgets/auth_form_test.dart
@@ -7,16 +7,26 @@ import 'package:metrics/auth/presentation/widgets/sign_in_option_button.dart';
 import 'package:metrics/auth/presentation/widgets/strategy/google_sign_in_option_strategy.dart';
 import 'package:metrics/base/presentation/widgets/tappable_area.dart';
 import 'package:metrics/common/presentation/button/widgets/metrics_positive_button.dart';
+import 'package:metrics/common/presentation/metrics_theme/model/login_theme_data.dart';
+import 'package:metrics/common/presentation/metrics_theme/model/metrics_theme_data.dart';
 import 'package:metrics/common/presentation/widgets/metrics_text_form_field.dart';
 import 'package:mockito/mockito.dart';
 import 'package:network_image_mock/network_image_mock.dart';
 
 import '../../../test_utils/auth_notifier_mock.dart';
+import '../../../test_utils/metrics_themed_testbed.dart';
 import '../../../test_utils/test_injection_container.dart';
 import '../state/auth_notifier_test.dart';
 
 void main() {
   group("AuthForm", () {
+    const passwordVisibilityIconColor = Colors.red;
+    const metricsThemeData = MetricsThemeData(
+      loginTheme: LoginThemeData(
+        passwordVisibilityIconColor: passwordVisibilityIconColor,
+      ),
+    );
+
     final emailInputFinder =
         find.widgetWithText(MetricsTextFormField, AuthStrings.email);
     final passwordInputFinder =
@@ -240,6 +250,27 @@ void main() {
     );
 
     testWidgets(
+      "applies the password visibility icon color from the metrics theme",
+      (WidgetTester tester) async {
+        await mockNetworkImagesFor(
+          () => tester.pumpWidget(
+            const _AuthFormTestbed(
+              metricsThemeData: metricsThemeData,
+            ),
+          ),
+        );
+
+        final suffixIcon = _getPasswordFieldSuffixIcon(tester);
+        final image = tester.widget<Image>(find.descendant(
+          of: find.byWidget(suffixIcon),
+          matching: find.byType(Image),
+        ));
+
+        expect(image.color, equals(passwordVisibilityIconColor));
+      },
+    );
+
+    testWidgets(
       "applies a tappable area to the suffix icon of the password field",
       (WidgetTester tester) async {
         await mockNetworkImagesFor(
@@ -269,8 +300,12 @@ class _AuthFormTestbed extends StatelessWidget {
   /// An [AuthNotifier] used in tests.
   final AuthNotifier authNotifier;
 
+  /// A [MetricsThemeData] to use in tests.
+  final MetricsThemeData metricsThemeData;
+
   /// Creates the [_AuthFormTestbed] with the given [authNotifier].
   const _AuthFormTestbed({
+    this.metricsThemeData = const MetricsThemeData(),
     this.authNotifier,
   });
 
@@ -278,10 +313,9 @@ class _AuthFormTestbed extends StatelessWidget {
   Widget build(BuildContext context) {
     return TestInjectionContainer(
       authNotifier: authNotifier,
-      child: MaterialApp(
-        home: Scaffold(
-          body: AuthForm(),
-        ),
+      child: MetricsThemedTestbed(
+        metricsThemeData: metricsThemeData,
+        body: AuthForm(),
       ),
     );
   }

--- a/metrics/web/test/common/presentation/metrics_theme/model/login_theme_data_test.dart
+++ b/metrics/web/test/common/presentation/metrics_theme/model/login_theme_data_test.dart
@@ -14,6 +14,7 @@ void main() {
         const themeData = LoginThemeData();
 
         expect(themeData.loginOptionButtonStyle, isNotNull);
+        expect(themeData.passwordVisibilityIconColor, isNotNull);
       },
     );
 
@@ -29,14 +30,18 @@ void main() {
     test("creates an instance with the given values", () {
       const titleTextStyle = TextStyle();
       const loginOptionButtonStyle = MetricsButtonStyle(color: Colors.white);
+      const passwordVisibilityIconColor = Colors.green;
 
       final themeData = LoginThemeData(
         titleTextStyle: titleTextStyle,
         loginOptionButtonStyle: loginOptionButtonStyle,
+        passwordVisibilityIconColor: passwordVisibilityIconColor,
       );
 
       expect(themeData.titleTextStyle, equals(titleTextStyle));
       expect(themeData.loginOptionButtonStyle, equals(loginOptionButtonStyle));
+      expect(themeData.passwordVisibilityIconColor,
+          equals(passwordVisibilityIconColor));
     });
   });
 }

--- a/metrics/web/test/common/presentation/metrics_theme/model/login_theme_data_test.dart
+++ b/metrics/web/test/common/presentation/metrics_theme/model/login_theme_data_test.dart
@@ -4,7 +4,7 @@ import 'package:metrics/common/presentation/metrics_theme/model/login_theme_data
 import 'package:test/test.dart';
 
 // https://github.com/software-platform/monorepo/issues/140
-// ignore_for_file: prefer_const_constructors
+// ignore_for_file: prefer_const_constructors, avoid_redundant_argument_values
 
 void main() {
   group("LoginThemeData", () {

--- a/metrics/web/test/common/presentation/metrics_theme/model/login_theme_data_test.dart
+++ b/metrics/web/test/common/presentation/metrics_theme/model/login_theme_data_test.dart
@@ -14,6 +14,14 @@ void main() {
         const themeData = LoginThemeData();
 
         expect(themeData.loginOptionButtonStyle, isNotNull);
+      },
+    );
+
+    test(
+      "creates a theme with the default visibility icon color if the given value is null",
+      () {
+        const themeData = LoginThemeData(passwordVisibilityIconColor: null);
+
         expect(themeData.passwordVisibilityIconColor, isNotNull);
       },
     );


### PR DESCRIPTION
Fixes #615 

## Checklist

- [x] Documented
- [x] Component tested

## Before
<img width="500" alt="Снимок экрана 2020-09-23 в 16 41 11" src="https://user-images.githubusercontent.com/69351065/94020463-9ba1b800-fdbb-11ea-93d6-7c4cbc1d9b81.png">

## Now
<img width="500" alt="Снимок экрана 2020-09-23 в 16 38 24" src="https://user-images.githubusercontent.com/69351065/94020102-351c9a00-fdbb-11ea-80c8-5e572c217a1b.png">
