### PR TITLE
feat: Extend the BuildkiteClient to include the `fetchBuild` method

### DIFF
--- a/metrics/ci_integrations/lib/client/buildkite/buildkite_client.dart
+++ b/metrics/ci_integrations/lib/client/buildkite/buildkite_client.dart
@@ -190,6 +190,36 @@ class BuildkiteClient with LoggerMixin {
     );
   }
 
+  /// Fetches a [BuildkiteBuild] by the given [pipelineSlug] and [buildNumber].
+  ///
+  /// Throws an [ArgumentError] if the given [pipelineSlug] or [buildNumber] is
+  /// `null`.
+  Future<InteractionResult<BuildkiteBuild>> fetchBuild(
+    String pipelineSlug,
+    int buildNumber,
+  ) {
+    ArgumentError.checkNotNull(pipelineSlug, 'pipelineSlug');
+    ArgumentError.checkNotNull(buildNumber, 'buildNumber');
+
+    logger.info('Fetching the build #$buildNumber...');
+
+    final url = UrlUtils.buildUrl(
+      basePath,
+      path: 'pipelines/$pipelineSlug/builds/buildNumber',
+    );
+
+    return _handleResponse(
+      _client.get(url, headers: headers),
+      (body, headers) {
+        final buildJson = body as Map<String, dynamic>;
+
+        return InteractionResult.success(
+          result: BuildkiteBuild.fromJson(buildJson),
+        );
+      },
+    );
+  }
+
   /// Fetches a [BuildkiteArtifactPage] by the given [pipelineSlug] and
   /// [buildNumber].
   ///

--- a/metrics/ci_integrations/lib/client/buildkite/buildkite_client.dart
+++ b/metrics/ci_integrations/lib/client/buildkite/buildkite_client.dart
@@ -205,7 +205,7 @@ class BuildkiteClient with LoggerMixin {
 
     final url = UrlUtils.buildUrl(
       basePath,
-      path: 'pipelines/$pipelineSlug/builds/buildNumber',
+      path: 'pipelines/$pipelineSlug/builds/$buildNumber',
     );
 
     return _handleResponse(

--- a/metrics/ci_integrations/lib/client/buildkite/buildkite_client.dart
+++ b/metrics/ci_integrations/lib/client/buildkite/buildkite_client.dart
@@ -190,16 +190,17 @@ class BuildkiteClient with LoggerMixin {
     );
   }
 
-  /// Fetches a [BuildkiteBuild] by the given [pipelineSlug] and [buildNumber].
+  /// Fetches a [BuildkiteBuild] of a pipeline with the given [pipelineSlug] 
+  /// and having the given [buildNumber].
   ///
-  /// Throws an [ArgumentError] if the given [pipelineSlug] or [buildNumber] is
+  /// Throws an [AssertionError] if the given [pipelineSlug] or [buildNumber] is
   /// `null`.
   Future<InteractionResult<BuildkiteBuild>> fetchBuild(
     String pipelineSlug,
     int buildNumber,
   ) {
-    ArgumentError.checkNotNull(pipelineSlug, 'pipelineSlug');
-    ArgumentError.checkNotNull(buildNumber, 'buildNumber');
+    assert(pipelineSlug != null);
+    assert(buildNumber != null);
 
     logger.info('Fetching the build #$buildNumber...');
 

--- a/metrics/ci_integrations/test/client/buildkite/buildkite_client_test.dart
+++ b/metrics/ci_integrations/test/client/buildkite/buildkite_client_test.dart
@@ -20,6 +20,7 @@ void main() {
   group("BuildkiteClient", () {
     const testPageNumber = 1;
     const buildNumber = 1;
+    const notFoundBuildNumber = -1;
     const organizationSlug = 'organization_slug';
     const pipelineSlug = 'pipeline_slug';
     const notFound = 'not_found';
@@ -416,9 +417,48 @@ void main() {
     );
 
     test(
+      ".fetchBuild() returns an error if the pipeline with the given slug is not found",
+      () async {
+        final interactionResult = await client.fetchBuild(
+          notFound,
+          buildNumber,
+        );
+
+        expect(interactionResult.isError, isTrue);
+      },
+    );
+
+    test(
+      ".fetchBuild() returns an error if the build with the build with the given build number is not found",
+      () async {
+        final interactionResult = await client.fetchBuild(
+          pipelineSlug,
+          notFoundBuildNumber,
+        );
+
+        expect(interactionResult.isError, isTrue);
+      },
+    );
+
+    test(
+      ".fetchBuild() returns a buildkite build",
+      () async {
+        final interactionResult = await client.fetchBuild(
+          pipelineSlug,
+          buildNumber,
+        );
+
+        expect(interactionResult.result, isNotNull);
+      },
+    );
+
+    test(
       ".fetchArtifacts() fails if an associated build with such number is not found",
       () async {
-        final interactionResult = await client.fetchArtifacts(pipelineSlug, 10);
+        final interactionResult = await client.fetchArtifacts(
+          pipelineSlug,
+          notFoundBuildNumber,
+        );
 
         expect(interactionResult.isError, isTrue);
       },

--- a/metrics/ci_integrations/test/client/buildkite/buildkite_client_test.dart
+++ b/metrics/ci_integrations/test/client/buildkite/buildkite_client_test.dart
@@ -463,6 +463,7 @@ void main() {
           pipelineSlug,
           buildNumber,
         );
+
         final build = interactionResult.result;
 
         expect(build.number, equals(buildNumber));

--- a/metrics/ci_integrations/test/client/buildkite/buildkite_client_test.dart
+++ b/metrics/ci_integrations/test/client/buildkite/buildkite_client_test.dart
@@ -457,7 +457,7 @@ void main() {
     );
 
     test(
-      ".fetchBuild() returns a buildkite build with the given build number",
+      ".fetchBuild() returns a buildkite build with build number equal to the requested one",
       () async {
         final interactionResult = await client.fetchBuild(
           pipelineSlug,

--- a/metrics/ci_integrations/test/client/buildkite/buildkite_client_test.dart
+++ b/metrics/ci_integrations/test/client/buildkite/buildkite_client_test.dart
@@ -400,24 +400,27 @@ void main() {
     );
 
     test(
-      ".fetchBuild() throws an ArgumentError if the given pipeline slug is null",
-      () async {
-        expect(() => client.fetchBuild(null, buildNumber), throwsArgumentError);
-      },
-    );
-
-    test(
-      ".fetchBuild() throws an ArgumentError if the given build number is null",
-      () async {
+      ".fetchBuild() throws an AssertionError if the given pipeline slug is null",
+      () {
         expect(
-          () => client.fetchBuild(pipelineSlug, null),
-          throwsArgumentError,
+          () => client.fetchBuild(null, buildNumber),
+          throwsA(isA<AssertionError>()),
         );
       },
     );
 
     test(
-      ".fetchBuild() returns an error if the pipeline with the given slug is not found",
+      ".fetchBuild() throws an AssertionError if the given build number is null",
+      () {
+        expect(
+          () => client.fetchBuild(pipelineSlug, null),
+          throwsA(isA<AssertionError>()),
+        );
+      },
+    );
+
+    test(
+      ".fetchBuild() returns an error if a pipeline with the given pipeline slug is not found",
       () async {
         final interactionResult = await client.fetchBuild(
           notFound,
@@ -429,7 +432,7 @@ void main() {
     );
 
     test(
-      ".fetchBuild() returns an error if the build with the build with the given build number is not found",
+      ".fetchBuild() returns an error if a build with the given build number is not found",
       () async {
         final interactionResult = await client.fetchBuild(
           pipelineSlug,
@@ -448,7 +451,21 @@ void main() {
           buildNumber,
         );
 
+        expect(interactionResult.isSuccess, isTrue);
         expect(interactionResult.result, isNotNull);
+      },
+    );
+
+    test(
+      ".fetchBuild() returns a buildkite build with the given build number",
+      () async {
+        final interactionResult = await client.fetchBuild(
+          pipelineSlug,
+          buildNumber,
+        );
+        final build = interactionResult.result;
+
+        expect(build.number, equals(buildNumber));
       },
     );
 

--- a/metrics/ci_integrations/test/client/buildkite/buildkite_client_test.dart
+++ b/metrics/ci_integrations/test/client/buildkite/buildkite_client_test.dart
@@ -399,6 +399,23 @@ void main() {
     );
 
     test(
+      ".fetchBuild() throws an ArgumentError if the given pipeline slug is null",
+      () async {
+        expect(() => client.fetchBuild(null, buildNumber), throwsArgumentError);
+      },
+    );
+
+    test(
+      ".fetchBuild() throws an ArgumentError if the given build number is null",
+      () async {
+        expect(
+          () => client.fetchBuild(pipelineSlug, null),
+          throwsArgumentError,
+        );
+      },
+    );
+
+    test(
       ".fetchArtifacts() fails if an associated build with such number is not found",
       () async {
         final interactionResult = await client.fetchArtifacts(pipelineSlug, 10);

--- a/metrics/ci_integrations/test/client/buildkite/test_utils/mock/buildkite_mock_server.dart
+++ b/metrics/ci_integrations/test/client/buildkite/test_utils/mock/buildkite_mock_server.dart
@@ -146,11 +146,12 @@ class BuildkiteMockServer extends ApiMockServer {
 
   /// Responses with a [BuildkiteBuild].
   Future<void> _buildResponse(HttpRequest request) async {
-    const build = BuildkiteBuild();
+    final buildNumber = _extractBuildNumber(request);
 
-    final response = build.toJson();
+    final build = BuildkiteBuild(number: buildNumber);
+    final data = build.toJson();
 
-    await MockServerUtils.writeResponse(request, body: response);
+    await MockServerUtils.writeResponse(request, body: data);
   }
 
   /// Responses with a list of [BuildkiteArtifact]s.
@@ -220,6 +221,13 @@ class BuildkiteMockServer extends ApiMockServer {
     );
 
     await request.response.close();
+  }
+
+  /// Returns the build number extracted from the given [request].
+  int _extractBuildNumber(HttpRequest request) {
+    final buildNumber = request.uri.pathSegments.last;
+
+    return int.tryParse(buildNumber);
   }
 
   /// Returns the [BuildkiteBuildState], based on the `state` query parameter

--- a/metrics/ci_integrations/test/client/buildkite/test_utils/mock/buildkite_mock_server.dart
+++ b/metrics/ci_integrations/test/client/buildkite/test_utils/mock/buildkite_mock_server.dart
@@ -145,7 +145,7 @@ class BuildkiteMockServer extends ApiMockServer {
   }
 
   /// Responses with a [BuildkiteBuild] with the build number extracted from
-  /// thr given [request].
+  /// the given [request].
   Future<void> _buildResponse(HttpRequest request) async {
     final buildNumber = _extractBuildNumber(request);
 

--- a/metrics/ci_integrations/test/client/buildkite/test_utils/mock/buildkite_mock_server.dart
+++ b/metrics/ci_integrations/test/client/buildkite/test_utils/mock/buildkite_mock_server.dart
@@ -144,7 +144,8 @@ class BuildkiteMockServer extends ApiMockServer {
     await MockServerUtils.writeResponse(request, body: response);
   }
 
-  /// Responses with a [BuildkiteBuild].
+  /// Responses with a [BuildkiteBuild] with the build number extracted from
+  /// thr given [request].
   Future<void> _buildResponse(HttpRequest request) async {
     final buildNumber = _extractBuildNumber(request);
 
@@ -223,7 +224,7 @@ class BuildkiteMockServer extends ApiMockServer {
     await request.response.close();
   }
 
-  /// Returns the build number extracted from the given [request].
+  /// Returns the build number extracted from the path of the given [request].
   int _extractBuildNumber(HttpRequest request) {
     final buildNumber = request.uri.pathSegments.last;
 

--- a/metrics/ci_integrations/test/client/buildkite/test_utils/mock/buildkite_mock_server.dart
+++ b/metrics/ci_integrations/test/client/buildkite/test_utils/mock/buildkite_mock_server.dart
@@ -40,13 +40,31 @@ class BuildkiteMockServer extends ApiMockServer {
         ),
         RequestHandler.get(
           pathMatcher: ExactPathMatcher(
+            '$basePath/pipelines/pipeline_slug/builds/1',
+          ),
+          dispatcher: _buildResponse,
+        ),
+        RequestHandler.get(
+          pathMatcher: ExactPathMatcher(
+            '$basePath/pipelines/not_found/builds/1',
+          ),
+          dispatcher: MockServerUtils.notFoundResponse,
+        ),
+        RequestHandler.get(
+          pathMatcher: ExactPathMatcher(
+            '$basePath/pipelines/pipeline_slug/builds/-1',
+          ),
+          dispatcher: MockServerUtils.notFoundResponse,
+        ),
+        RequestHandler.get(
+          pathMatcher: ExactPathMatcher(
             '$basePath/pipelines/pipeline_slug/builds/1/artifacts',
           ),
           dispatcher: _pipelineBuildArtifactsResponse,
         ),
         RequestHandler.get(
           pathMatcher: ExactPathMatcher(
-            '$basePath/pipelines/pipeline_slug/builds/not_found/artifacts',
+            '$basePath/pipelines/pipeline_slug/builds/-1/artifacts',
           ),
           dispatcher: MockServerUtils.notFoundResponse,
         ),
@@ -122,6 +140,15 @@ class BuildkiteMockServer extends ApiMockServer {
     builds = MockServerUtils.paginate(builds, perPage, pageNumber);
 
     final response = builds.map((build) => build.toJson()).toList();
+
+    await MockServerUtils.writeResponse(request, body: response);
+  }
+
+  /// Responses with a [BuildkiteBuild].
+  Future<void> _buildResponse(HttpRequest request) async {
+    const build = BuildkiteBuild();
+
+    final response = build.toJson();
 
     await MockServerUtils.writeResponse(request, body: response);
   }


### PR DESCRIPTION
Fixes #1274

## Checklist

- [x] Documented
- [x] Unit tested